### PR TITLE
Fix region NPE and concurrency computation

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -25,6 +25,11 @@ dependencies {
     compileOnly("com.mysql:mysql-connector-j:9.3.0")
     compileOnly 'de.bluecolored:bluemap-api:2.7.4'
     implementation 'org.xerial:sqlite-jdbc:3.46.0.0'
+
+    testImplementation("io.papermc.paper:paper-api:1.21.5-R0.1-SNAPSHOT")
+
+    testImplementation 'org.junit.jupiter:junit-jupiter:5.10.2'
+    testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 }
 
 tasks {
@@ -52,6 +57,10 @@ tasks.withType(JavaCompile).configureEach {
     if (targetJavaVersion >= 10 || JavaVersion.current().isJava10Compatible()) {
         options.release.set(targetJavaVersion)
     }
+}
+
+test {
+    useJUnitPlatform()
 }
 
 processResources {

--- a/src/test/java/ru/helicraft/states/regions/RegionGeneratorTest.java
+++ b/src/test/java/ru/helicraft/states/regions/RegionGeneratorTest.java
@@ -1,0 +1,27 @@
+package ru.helicraft.states.regions;
+
+import org.junit.jupiter.api.Test;
+import ru.helicraft.states.regions.RegionGenerator;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class RegionGeneratorTest {
+    @Test
+    void testComputeConcurrencyZeroUsesCpuTimes2() {
+        int cpus = 4;
+        int res = RegionGenerator.computeConcurrency(0, cpus);
+        assertEquals(cpus * 2, res);
+    }
+
+    @Test
+    void testComputeConcurrencyPositive() {
+        int res = RegionGenerator.computeConcurrency(5, 8);
+        assertEquals(5, res);
+    }
+
+    @Test
+    void testComputeConcurrencyNegativeClamped() {
+        int res = RegionGenerator.computeConcurrency(-1, 2);
+        assertEquals(4, res); // 2 * 2
+    }
+}


### PR DESCRIPTION
## Summary
- avoid NPE when merging small regions
- add helper to compute sampling concurrency
- use that helper in generator
- use generic logger to avoid plugin dependency
- add junit tests for concurrency logic
- add junit & Paper API test deps

## Testing
- `gradle test --console=plain`

------
https://chatgpt.com/codex/tasks/task_e_6844dac0ca548323a7db1d34803b706c