### PR TITLE
Fix traceBoundary loops and expose limits

### DIFF
--- a/src/main/java/ru/helicraft/helistates/HeliStates.java
+++ b/src/main/java/ru/helicraft/helistates/HeliStates.java
@@ -49,6 +49,8 @@ public final class HeliStates extends JavaPlugin {
         cfg.MAX_CELLS      = getConfig().getInt   ("regions.maxCells",       3000);
         cfg.COAST_BUFFER   = getConfig().getInt   ("regions.coastBuffer",      50);
         cfg.CHAIKIN_ITER   = getConfig().getInt   ("regions.chaikinIter",       3);
+        cfg.boundaryStepLimitFactor = getConfig().getInt(
+                "regions.boundaryStepLimitFactor", 8);
         cfg.maxParallelSamples = getConfig().getInt("regions.maxParallelSamples", 0);
 
         regionManager = new RegionManager(databaseManager, cfg);

--- a/src/main/java/ru/helicraft/states/regions/RegionGenerator.java
+++ b/src/main/java/ru/helicraft/states/regions/RegionGenerator.java
@@ -558,7 +558,7 @@ public final class RegionGenerator {
         int spacing = g.spacing;
 
         do {
-            long state = (((long) x & 0xffffffffL) << 32)
+            long state = (((long) x & 0xffffffffL) << 34)
                     | ((long) (z & 0xffffffffL) << 2)
                     | (dir & 0x3);
             if (!visited.add(state) || ++steps > maxSteps) {

--- a/src/main/java/ru/helicraft/states/regions/RegionGenerator.java
+++ b/src/main/java/ru/helicraft/states/regions/RegionGenerator.java
@@ -75,6 +75,13 @@ public final class RegionGenerator {
 
         /** Итерации Chaikin. */
         public int CHAIKIN_ITER = 3;
+
+        /**
+         * Multiplier for boundary tracing step limit. Ring tracing stops after
+         * {@code cells.size() * boundaryStepLimitFactor} iterations to avoid
+         * runaway loops. Higher values are safer but may increase memory usage.
+         */
+        public int boundaryStepLimitFactor = 8;
     }
 
     /**
@@ -470,6 +477,10 @@ public final class RegionGenerator {
         List<Region> out = new ArrayList<>();
         for (var e : regCells.entrySet()) {
             List<Cell> cells = e.getValue();
+            if (HeliStates.DEBUG) {
+                LOG.info("[DEBUG] buildRegionObjects: id=" + e.getKey() +
+                        " cells=" + cells.size());
+            }
             /* Считаем площадь и доминирующий биом */
             Map<Biome,Integer> cnt = new HashMap<>();
             int area = 0;
@@ -499,6 +510,10 @@ public final class RegionGenerator {
             /* Сглаживаем Chaikin-ом */
             for (int i = 0; i < cfg.CHAIKIN_ITER; i++) ring = chaikin(ring);
 
+            if (HeliStates.DEBUG) {
+                LOG.info("[DEBUG] region " + e.getKey() + " ring vertices=" + ring.size());
+            }
+
             out.add(new Region(UUID.randomUUID(), ring, area, dom));
         }
         return out;
@@ -523,29 +538,51 @@ public final class RegionGenerator {
     /* ---------- Грубый обход края (Marching Squares lite) ---------- */
 
     private List<Vector> traceBoundary(List<Cell> cells, Grid g) {
-        Set<Long> S = new HashSet<>(cells.size()*2);
-        cells.forEach(c -> S.add(((long)c.gx<<32)| (c.gz&0xffffffffL)));
+        if (HeliStates.DEBUG) {
+            LOG.info("[DEBUG] traceBoundary: cells=" + cells.size());
+        }
+
+        Set<Long> S = new HashSet<>(cells.size() * 2);
+        cells.forEach(c -> S.add(((long) c.gx << 32) | (c.gz & 0xffffffffL)));
 
         int[] dx = {1, 0, -1, 0}, dz = {0, 1, 0, -1};
         Cell start = cells.stream()
                 .min(Comparator.comparingInt(c -> c.gx * 100000 + c.gz))
                 .orElse(cells.get(0));
         int dir = 0;
-        List<Vector> ring = new ArrayList<>();
+        List<Vector> ring = new ArrayList<>(cells.size() * 4);
+        Set<Long> visited = new HashSet<>(cells.size() * 4);
+        int maxSteps = cells.size() * cfg.boundaryStepLimitFactor;
+        int steps = 0;
         int x = start.gx, z = start.gz;
         int spacing = g.spacing;
 
         do {
+            long state = (((long) x & 0xffffffffL) << 32)
+                    | ((long) (z & 0xffffffffL) << 2)
+                    | (dir & 0x3);
+            if (!visited.add(state) || ++steps > maxSteps) {
+                LOG.warning("[DEBUG] traceBoundary: loop detected or too many steps (" + steps + ")");
+                break;
+            }
+
             ring.add(new Vector(x * spacing, 0, z * spacing));
             /* Поворачиваем пока слева внутри */
             for (int i = 0; i < 4; i++) {
                 int nd = (dir + 3) % 4;
                 int nx = x + dx[nd], nz = z + dz[nd];
-                if (S.contains(((long)nx<<32)|(nz&0xffffffffL))) { dir = nd; break; }
+                if (S.contains(((long) nx << 32) | (nz & 0xffffffffL))) {
+                    dir = nd; break;
+                }
                 dir = (dir + 1) % 4;
             }
-            x += dx[dir]; z += dz[dir];
+            x += dx[dir];
+            z += dz[dir];
         } while (!(x == start.gx && z == start.gz && ring.size() > 1));
+
+        if (HeliStates.DEBUG) {
+            LOG.info("[DEBUG] traceBoundary: ring size=" + ring.size());
+        }
 
         return ring;
     }

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -1,14 +1,26 @@
 enabled: false
 debug: false
 regions:
+  # Radius around spawn to process, blocks. Larger values dramatically
+  # increase generation time.
   worldRadius: 5000
+  # Height-map sampling step in blocks. Lower values give more precise
+  # regions but slow generation.
   sampleSpacing: 8
   terrainWeight: 1.0
   biomeWeight: 0.4
+  # Region size thresholds used when merging and splitting.
   minCells: 30
   maxCells: 3000
+  # Distance from shore kept when discarding ocean regions.
   coastBuffer: 50
+  # Chaikin smoothing iterations. More iterations produce smoother
+  # polygons but require extra processing time.
   chaikinIter: 3
+  # Limit for steps during boundary tracing expressed as multiplier of
+  # region cell count.
+  boundaryStepLimitFactor: 8
+  # Maximum simultaneously sampled chunks. Set to 0 to use CPU x2.
   maxParallelSamples: 0  # 0 => use CPU x2
 
 database:


### PR DESCRIPTION
## Summary
- avoid runaway memory by adding visited state tracking and step limit in traceBoundary
- log region information when building polygons
- load new boundaryStepLimitFactor from config
- document performance-related settings in `config.yml`

## Testing
- `gradle test`

------
https://chatgpt.com/codex/tasks/task_e_6844de6a4c348323ba97c34c544f165f